### PR TITLE
Feat: Checkmk Inventory now supports Configuration and HW_SW Inventory

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -16,7 +16,7 @@ from flask_mongoengine import MongoEngine
 from flask_admin.contrib.fileadmin import FileAdmin
 
 
-VERSION = '3.5.1'
+VERSION = '3.5.2'
 # create logger
 logger = logging.getLogger('cmdb_syncer')
 
@@ -154,6 +154,10 @@ admin.add_view(FiltereModelView(CheckmkFilterRule, name="Filter", category="Chec
 admin.add_view(CheckmkRuleView(CheckmkRule, name="Export Rules", category="Checkmk"))
 admin.add_view(CheckmkGroupRuleView(CheckmkGroupRule, \
                                     name="Checkmk Groups Management", category="Checkmk"))
+
+from application.modules.checkmk.models import CheckmkInventorizeAttributes
+admin.add_view(DefaultModelView(CheckmkInventorizeAttributes, name="Inventorize Settings",
+                                                            category="Checkmk"))
 
 from application.modules.checkmk.models import CheckmkRuleMngmt
 from application.modules.checkmk.views import CheckmkMngmtRuleView

--- a/application/models/host.py
+++ b/application/models/host.py
@@ -171,6 +171,8 @@ class Host(db.Document):
         """
         # pylint: disable=unnecessary-comprehension
         # Prevent runtime error
+        if not new_data:
+            return
         check_dict = {}
         for name, value in [(x,y) for x,y in self.inventory.items()]:
             # Delete all existing keys of type

--- a/application/models/host.py
+++ b/application/models/host.py
@@ -181,6 +181,8 @@ class Host(db.Document):
         update_dict = {f"{key}/{x}":y for x, y in new_data.items()}
         self.inventory.update(update_dict)
 
+        # If the inventory is changed, the cache 
+        # is not longer valid
         if check_dict != update_dict:
             self.cache = {}
 

--- a/application/modules/checkmk/inits.py
+++ b/application/modules/checkmk/inits.py
@@ -95,6 +95,14 @@ def inventorize_hosts(account):
     cmk = CMK2()
     cmk.config = config
 
+
+    # Check if Rules are set,
+    # If not, abort to prevent loss of data
+    if not fields:
+        raise CmkException("No Inventory Rules configured")
+
+
+
     print(f"{ColorCodes.OKBLUE}Started {ColorCodes.ENDC} with account "\
           f"{ColorCodes.UNDERLINE}{account}{ColorCodes.ENDC}")
 

--- a/application/modules/checkmk/inits.py
+++ b/application/modules/checkmk/inits.py
@@ -3,13 +3,15 @@
 Inits for the Plugins
 """
 #pylint: disable=too-many-locals
+import base64
+import ast
 from application.helpers.get_account import get_account_by_name
 from application.modules.checkmk.cmk2 import CMK2, CmkException
 from application.modules.debug import ColorCodes
 from application.models.host import Host
 from application.modules.checkmk.config_sync import SyncConfiguration
 from application.modules.checkmk.rules import CheckmkRulesetRule, DefaultRule
-from application.modules.checkmk.models import CheckmkRuleMngmt, CheckmkBiRule, CheckmkBiAggregation
+from application.modules.checkmk.models import CheckmkRuleMngmt, CheckmkBiRule, CheckmkBiAggregation, CheckmkInventorizeAttributes
 from application.plugins.checkmk import _load_rules
 
 
@@ -81,13 +83,14 @@ def inventorize_hosts(account):
     """
     Inventorize information from Checkmk Installation
     """
-    inventory_blacklist = [
-        'labels', 'locked_by', 'locked_attributes', 'network_scan'
-    ]
 
-    pull_extra_values = [
-        'folder', 'is_cluster', 'is_offline'
-    ]
+    fields = {}
+
+    for rule in CheckmkInventorizeAttributes.objects():
+        fields.setdefault(rule.attribute_source, [])
+        field_list = [x.strip() for x in rule.attribute_names.split(',')]
+        fields[rule.attribute_source] += field_list
+
     config = get_account_by_name(account)
     cmk = CMK2()
     cmk.config = config
@@ -95,63 +98,115 @@ def inventorize_hosts(account):
     print(f"{ColorCodes.OKBLUE}Started {ColorCodes.ENDC} with account "\
           f"{ColorCodes.UNDERLINE}{account}{ColorCodes.ENDC}")
 
-
-    print(f"{ColorCodes.OKBLUE} *{ColorCodes.ENDC} Collecting Config Data")
-    url = "domain-types/host_config/collections/all?effective_attributes=true"
-    api_hosts = cmk.request(url, method="GET")
-    config_inventory = {}
-    for host in api_hosts[0]['value']:
-        hostname = host['id']
-        attributes = host['extensions']['effective_attributes']
-        host_inventory = {}
-        for attribute in attributes:
-            if attribute not in inventory_blacklist:
-                host_inventory[attribute] = attributes[attribute]
-        for label_key, label_value in attributes['labels'].items():
-            if label_key.startswith('cmk/'):
-                label_key = label_key.replace('cmk/','')
-                host_inventory['label_'+label_key] = label_value
-
-        for extra in pull_extra_values:
-            host_inventory[extra] = host['extensions'][extra]
-
-        config_inventory[hostname] = host_inventory
-
-
     # Inventory for Status Information
-    url = "domain-types/service/collections/all"
-    params={
-        "query":
-           '{"op": "or", "expr": ['\
-           '{ "op": "=", "left": "description", "right": "Check_MK"}, '\
-           '{ "op": "=", "left": "description", "right": "Check_MK Agent"},'\
-           '{ "op": "=", "left": "description", "right": "Check_MK Discovery"}'\
-           '] }',
-        "columns":
-           ['host_name', 'description', 'state', 'plugin_output', 'host_labels'],
-    }
     print(f"{ColorCodes.OKBLUE} *{ColorCodes.ENDC} Collecting Status Data")
+    url = "domain-types/service/collections/all"
+
+    columns = ['host_name', 'description', 'state', 'plugin_output', 'host_labels']
+
+    if fields.get('cmk_inventory'):
+        columns.append('host_mk_inventory')
+    if fields.get('cmk_services'):
+        expr = ''
+        for field in fields['cmk_services']:
+            expr += f'{{ "op": "=", "left": "description", "right": "{field}"}},'
+        expr = expr[:-1]
+        params={
+            "query":
+               '{"op": "or",'\
+               f' "expr": [{expr}]'\
+               '}',
+
+            "columns": columns
+        }
+    else:
+        params={
+            "query":
+               '{ "op": "=", "left": "description", "right": "Check_MK"}',
+            "columns": columns
+        }
+
     api_response = cmk.request(url, data=params, method="GET")
     status_inventory = {}
     label_inventory = {}
+    hw_sw_inventory = {}
     for service in api_response[0]['value']:
-        host_name = service['extensions']['host_name']
+        hostname = service['extensions']['host_name']
         service_description = service['extensions']['description'].lower().replace(' ', '_')
         service_state = service['extensions']['state']
         service_output = service['extensions']['plugin_output']
         labels = service['extensions']['host_labels']
-        status_inventory.setdefault(host_name, {})
-        label_inventory.setdefault(host_name, {})
+        status_inventory.setdefault(hostname, {})
+        label_inventory.setdefault(hostname, {})
         for label, label_value in labels.items():
-            if not label.startswith('cmk/'):
-                continue
-            label_inventory[host_name][label.replace('cmk/','')] = label_value
+            label_inventory[hostname][label] = label_value
+        if fields.get('cmk_inventory'):
+            hw_sw_inventory.setdefault(hostname, {})
+            raw_inventory = service['extensions']['host_mk_inventory']['value'].encode('ascii')
+            hw_sw_inventory[hostname] = base64.b64decode(raw_inventory).decode('utf-8')
 
-        status_inventory[host_name][f"{service_description}_state"] = service_state
-        status_inventory[host_name][f"{service_description}_output"] = service_output
+        status_inventory[hostname][f"{service_description}_state"] = service_state
+        status_inventory[hostname][f"{service_description}_output"] = service_output
+
+    if fields.get('cmk_attributes') or fields.get('cmk_labels'):
+        print(f"{ColorCodes.OKBLUE} *{ColorCodes.ENDC} Collecting Config Data")
+        url = "domain-types/host_config/collections/all?effective_attributes=true"
+        api_hosts = cmk.request(url, method="GET")
+        config_inventory = {}
+        for host in api_hosts[0]['value']:
+            hostname = host['id']
+            attributes = host['extensions']
+            attributes.update(host['extensions']['effective_attributes'])
+
+            host_inventory = {}
+
+            if fields.get('cmk_attributes'):
+                for attribute_key, attribute_value in attributes.items():
+                    if attribute_key in fields['cmk_attributes']:
+                        host_inventory[attribute_key] = attribute_value
+                for search in fields['cmk_attributes']:
+                    if search.endswith('*'):
+                        needle = search[:-1]
+                        for attribute_key, attribute_value in attributes.items():
+                            if attribute_key.startswith(needle):
+                                host_inventory[attribute_key] = attribute_value
+
+            if fields.get('cmk_labels'):
+                labels = label_inventory[hostname]
+                labels.update(attributes['labels'])
+                for label_key, label_value in labels.items():
+                    if label_key in fields['cmk_labels']:
+                        label_key = label_key.replace('cmk/','')
+                        host_inventory['label_'+label_key] = label_value
+
+                for search in fields['cmk_labels']:
+                    if search.endswith('*'):
+                        needle = search[:-1]
+                        for label in labels.keys():
+                            if label.startswith(needle):
+                                label_name = label.replace('cmk/','')
+                                host_inventory['label_'+label_name] = labels[label]
+
+            config_inventory[hostname] = host_inventory
+
+
+            if hw_sw_inventory.get(hostname):
+                print(f"{ColorCodes.OKBLUE} *{ColorCodes.ENDC} Parsing HW/SW Inventory Data")
+                inv_data = ast.literal_eval(hw_sw_inventory[hostname])
+                hw_sw_inventory[hostname] = {}
+                for field in fields['cmk_inventory']:
+                    paths = field.split('.')
+                    if len(paths) == 1:
+                        inv_pairs = inv_data['Nodes'][paths[0]]['Attributes']['Pairs']
+                    elif len(paths) == 2:
+                        inv_pairs = \
+                            inv_data['Nodes'][paths[0]]['Nodes'][paths[1]]['Attributes']['Pairs']
+
+                    for key, value in inv_pairs.items():
+                        hw_sw_inventory[hostname][f'{paths[0]}/{key}'] = value
+
 
     print(f"{ColorCodes.UNDERLINE}Write to DB{ColorCodes.ENDC}")
-
 
     # pylint: disable=consider-using-dict-items
     for hostname in config_inventory:
@@ -159,7 +214,7 @@ def inventorize_hosts(account):
         if db_host:
             db_host.update_inventory('cmk', config_inventory[hostname])
             db_host.update_inventory('cmk_svc', status_inventory.get(hostname, {}))
-            db_host.update_inventory('cmk_label', label_inventory.get(hostname, {}))
+            db_host.update_inventory('cmk_hw_sw_inv', hw_sw_inventory.get(hostname, {}))
             db_host.save()
             print(f" {ColorCodes.OKGREEN}* {ColorCodes.ENDC} Updated {hostname}")
         else:

--- a/application/modules/checkmk/models.py
+++ b/application/modules/checkmk/models.py
@@ -5,6 +5,23 @@ Checkmk Rules
 from application import db
 from application.modules.rule.models import rule_types
 
+
+
+attriubte_sources = [
+    ("cmk_inventory",  "HW/SW Inventory"),
+    ("cmk_services", "Service Plugin Output"),
+    ("cmk_attributes", "Attributes of Host"),
+    ("cmk_labels", "Labels of Host"),
+]
+
+class CheckmkInventorizeAttributes(db.Document):
+    """
+    Attributes to be inventorized from Checkmk
+    """
+    attribute_names = db.StringField(required=True)
+    attribute_source = db.StringField(choices=attriubte_sources)
+
+
 #   .-- Checkmk Attribute Filter
 class CheckmkFilterRule(db.Document):
     """


### PR DESCRIPTION
With this Version, it's possible (and necessary) to configure which values you want to inventorize from Checkmk.
In Exchange for the Need to configure these values, you can now get every Attribute, Label, Tag, Service you want.


### General:
The configuration can be found in Rules → Checkmk → Inventorize Settings
All Rules can have a comma separated List of Values. If a Value ends with *, this will be 
a wildcard for every value starting with the given string. Wildcards will not work for the HW/SW Inventory or Checkmk Services. 

<img width="935" alt="Bildschirmfoto 2024-01-02 um 17 54 20" src="https://github.com/kuhn-ruess/cmdbsyncer/assets/899110/01c19d8c-f5ea-45df-a063-a665bd7b2787">


### HW/ SW Inventory:
You can set up to two levels, separated by dot.

 Examples:
- hardware.cpu
- networking 

### Checkmk Services
You need to specify the Exact Service Name. 
You then get two Attributes with the Service Output and the Service State

### Checkmk Attributes
Here you can get Tags and all API Fields from the Checkmk API

Examples:
- is_cluster
- folder
- site


### Checkmk Labels:
Here you can get all Labels of a Host in Checkmk;

Example:
- cmk/*


