### PR TITLE
Add custom CA certificate configuration and notice system

### DIFF
--- a/.github/workflows/update-build-date.yml
+++ b/.github/workflows/update-build-date.yml
@@ -1,7 +1,9 @@
 name: Update build date on push
 
 on:
-  push
+  push:
+    branches:
+      - main
 
 permissions:
     contents: write

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -29,7 +29,7 @@ warnings.filterwarnings('ignore', category=UserWarning)
 tablib_registry.register('syncer_rules', ExportObjects())
 
 
-VERSION = '3.12.4'
+VERSION = '3.12.5'
 
 CONFIG_MAP = {
     'prod': 'application.config.ProductionConfig',

--- a/application/modules/plugin.py
+++ b/application/modules/plugin.py
@@ -8,6 +8,8 @@ import time
 import json as mod_json
 import atexit
 import uuid
+import os
+import tempfile
 
 from pprint import pformat
 from collections import namedtuple
@@ -80,17 +82,18 @@ class Plugin():
     def __init__(self, account=False):
         """
         Initialize the plugin instance.
-        
+
         Args:
             account (str|bool, optional): Account identifier to load configuration.
                                         If False, no account is loaded. Defaults to False.
-                                        
+
         Raises:
             ValueError: If the specified account is invalid or not found.
         """
         self.start_time = time.time()
         self.log_details = []
         self.debug_lines = []
+        self._ca_cert_tempfile = None
         self.log_details.append(('started', datetime.now()))
         if account:
             self.config = get_account(account)
@@ -99,12 +102,29 @@ class Plugin():
             self.account_name = self.config['name']
             self.account_id = str(self.config['_id'])
             self.log_details.append(('Account', self.config['name']))
-            self.verify = self.config.get('verify_cert')
+            verify_cert = self.config.get('verify_cert')
+            self.verify = verify_cert if verify_cert is not None else True
 
         if app.config.get('DISABLE_SSL_ERRORS'):
             # Legacy Behavior -> Global Setting Overwrite. Deprecated start v3.8.2
             self.verify = not app.config.get('DISABLE_SSL_ERRORS')
 
+        if account and self.verify not in ["", False]:
+            chain_path = (self.config.get('ca_cert_chain') or '').strip()
+            root_path = (self.config.get('ca_root_cert') or '').strip()
+            cert_parts = []
+            for cert_file_path in filter(None, [chain_path, root_path]):
+                try:
+                    with open(cert_file_path, 'r', encoding='utf-8') as f:
+                        cert_parts.append(f.read().strip())
+                except OSError as e:
+                    logger.warning(f"Could not read CA cert file '{cert_file_path}': {e}")
+            if cert_parts:
+                fd, path = tempfile.mkstemp(suffix='.pem', prefix='cmdbsyncer_ca_')
+                with os.fdopen(fd, 'w') as bundle_file:
+                    bundle_file.write('\n'.join(cert_parts))
+                self._ca_cert_tempfile = path
+                self.verify = path
 
         if not self.source:
             self.source = self.__class__.__qualname__.replace('.','')
@@ -115,7 +135,7 @@ class Plugin():
     def save_log(self):
         """
         Save plugin execution details to the log system.
-        
+
         This method is automatically called at exit via atexit.register().
         It calculates the total execution duration and saves all collected
         log details including start time, end time, and duration.
@@ -125,6 +145,12 @@ class Plugin():
         self.log_details.append(('ended', datetime.now()))
 
         log.log(self.name, source=self.source, details=self.log_details)
+
+        if self._ca_cert_tempfile:
+            try:
+                os.unlink(self._ca_cert_tempfile)
+            except OSError:
+                pass
 
 
 

--- a/application/plugins/bmc_remedy/plugin.json
+++ b/application/plugins/bmc_remedy/plugin.json
@@ -10,7 +10,9 @@
         "hostname_field": "dnshostname",
         "namespace": "",
         "class_name": "",
-        "verify_cert": "True"
+        "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": ""
     },
     "enabled": true
 }

--- a/application/plugins/checkmk/plugin.json
+++ b/application/plugins/checkmk/plugin.json
@@ -16,6 +16,8 @@
         "dont_delete_hosts_if_more_then": "",
         "dont_activate_changes_if_more_then": "",
         "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": "",
         "import_filter": ""
     },
     "enabled": true

--- a/application/plugins/jira/plugin.json
+++ b/application/plugins/jira/plugin.json
@@ -8,7 +8,9 @@
     },
     "account_custom_field_presets": {
         "page_size": "1000",
-        "verify_cert": "True"
+        "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": ""
     },
     "enabled": true
 }

--- a/application/plugins/jira_cloud/plugin.json
+++ b/application/plugins/jira_cloud/plugin.json
@@ -9,7 +9,9 @@
     "account_custom_field_presets": {
         "workspace_id": "Required",
         "ql_query": "Required",
-        "verify_cert": "True"
+        "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": ""
     },
     "enabled": true
 }

--- a/application/plugins/netbox/netbox.py
+++ b/application/plugins/netbox/netbox.py
@@ -29,10 +29,7 @@ class SyncNetbox(Plugin):
         if self.config:
             # Not needed in Debug_host Mode
             self.nb = pynetbox.api(self.config['address'], token=self.config['password'])
-            verify = False
-            if 'true' in self.config.get('verify_cert', 'true').lower():
-                verify = True
-            self.nb.http_session.verify = verify
+            self.nb.http_session.verify = self.verify
 #.
 #   . -- Helpers
     @staticmethod

--- a/application/plugins/netbox/plugin.json
+++ b/application/plugins/netbox/plugin.json
@@ -6,6 +6,8 @@
     "account_custom_field_presets": {
         "rewrite_hostname": "",
         "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": "",
         "import_filter": "",
         "delete_host_if_not_found_on_import": ""
     },

--- a/application/plugins/rest/plugin.json
+++ b/application/plugins/rest/plugin.json
@@ -15,6 +15,8 @@
         "hostname_field": "host",
         "rewrite_hostname": "",
         "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": "",
         "path": ""
     },
     "enabled": true

--- a/application/plugins/yml/plugin.json
+++ b/application/plugins/yml/plugin.json
@@ -14,6 +14,8 @@
         "name_of_variables_key": "",
         "rewrite_hostname": "",
         "verify_cert": "True",
+        "ca_cert_chain": "",
+        "ca_root_cert": "",
         "path": "",
     },
     "enabled": true

--- a/application/templates/admin/index.html
+++ b/application/templates/admin/index.html
@@ -25,7 +25,43 @@ label {
 </style>
 
 <script>
+function confirmNotice(noticeId) {
+  if (!confirm('Have you checked and confirmed this notice?')) return;
+  const confirmed = JSON.parse(localStorage.getItem('confirmed-notices') || '[]');
+  if (!confirmed.includes(noticeId)) {
+    confirmed.push(noticeId);
+    localStorage.setItem('confirmed-notices', JSON.stringify(confirmed));
+  }
+  const el = document.getElementById('notice-' + noticeId);
+  if (el) el.style.display = 'none';
+
+  // Hide section header if all notices are gone
+  const remaining = document.querySelectorAll('.notice-box');
+  const anyVisible = Array.from(remaining).some(n => n.style.display !== 'none');
+  if (!anyVisible) {
+    const section = document.getElementById('notices-section');
+    if (section) section.style.display = 'none';
+  }
+}
+
+function applyConfirmedNotices() {
+  const confirmed = JSON.parse(localStorage.getItem('confirmed-notices') || '[]');
+  confirmed.forEach(function(noticeId) {
+    const el = document.getElementById('notice-' + noticeId);
+    if (el) el.style.display = 'none';
+  });
+
+  const remaining = document.querySelectorAll('.notice-box');
+  const anyVisible = Array.from(remaining).some(n => n.style.display !== 'none');
+  if (!anyVisible) {
+    const section = document.getElementById('notices-section');
+    if (section) section.style.display = 'none';
+  }
+}
+
 document.addEventListener('DOMContentLoaded', function() {
+  applyConfirmedNotices();
+
   // Style changelog entries and add filter functionality
   styleAndInitializeFilter();
   
@@ -165,6 +201,23 @@ function toggleAllFilters() {
     <p>
       Build: {{config.BUILD_DATE}}
     </p>
+
+    {% if notices %}
+    <div id="notices-section" style="margin-top: 20px;">
+      <h4>Messages</h4>
+      {% for notice in notices %}
+      <div id="notice-{{ notice.id }}"
+           class="notice-box"
+           style="background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 0.375rem; padding: 0.75rem 1rem; margin-bottom: 10px;">
+        <div style="white-space: pre-wrap; margin-bottom: 8px;">{{ notice.content|safe }}</div>
+        <button onclick="confirmNotice('{{ notice.id }}')"
+                style="background: #ffc107; color: #212529; border: none; padding: 4px 12px; border-radius: 3px; cursor: pointer; font-weight: bold;">
+          Confirm
+        </button>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
   </div>
 
   <!-- Right Column: Changelog -->

--- a/application/views/default.py
+++ b/application/views/default.py
@@ -2,6 +2,8 @@
 Default Model Views
 """
 import os
+import re
+import html
 from copy import deepcopy
 from flask import url_for, redirect, flash, request
 from flask_login import current_user
@@ -158,6 +160,33 @@ class IndexView(AdminIndexView):
             
         return '\n'.join(html_lines)
 
+    def _load_notices(self):
+        """
+        Load all notice files from the notices/ directory.
+        Returns list of dicts with 'id' and 'content'.
+        """
+        notices = []
+        notices_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'notices')
+        if not os.path.isdir(notices_dir):
+            return notices
+        for filename in sorted(os.listdir(notices_dir)):
+            if filename.endswith('.txt'):
+                notice_id = filename[:-4]  # strip .txt
+                filepath = os.path.join(notices_dir, filename)
+                try:
+                    with open(filepath, 'r', encoding='utf-8') as f:
+                        content = f.read().strip()
+                    escaped = html.escape(content)
+                    linked = re.sub(
+                        r'(https?://[^\s]+)',
+                        r'<a href="\1" target="_blank">\1</a>',
+                        escaped
+                    )
+                    notices.append({'id': notice_id, 'content': linked})
+                except Exception:
+                    pass
+        return notices
+
     @expose('/')
     def index(self):
         """
@@ -175,5 +204,7 @@ class IndexView(AdminIndexView):
             changelog_html = "<p>Changelog not found.</p>"
         except Exception:
             changelog_html = "<p>Error loading changelog.</p>"
-        
-        return self.render('admin/index.html', changelog_html=changelog_html)
+
+        notices = self._load_notices()
+
+        return self.render('admin/index.html', changelog_html=changelog_html, notices=notices)

--- a/changelog/v3.12.md
+++ b/changelog/v3.12.md
@@ -1,6 +1,9 @@
 ### Version 3.12.5
 
 - FEAT: Accounts can now configure custom CA certificate chain and root CA certificate for SSL verification
+
+### Version 3.12.4
+
 - FIX: Checkmk Log entry (error level) is now written when no pool folder is available for a host
 - FEAT: CMDB Mode is now further Optimized
 - FEAT: CMDB Mode now can auto match Tempaltes

--- a/changelog/v3.12.md
+++ b/changelog/v3.12.md
@@ -1,5 +1,6 @@
-### Version 3.12.4
+### Version 3.12.5
 
+- FEAT: Accounts can now configure custom CA certificate chain and root CA certificate for SSL verification
 - FIX: Checkmk Log entry (error level) is now written when no pool folder is available for a host
 - FEAT: CMDB Mode is now further Optimized
 - FEAT: CMDB Mode now can auto match Tempaltes

--- a/notices/strict_certificate_verification.txt
+++ b/notices/strict_certificate_verification.txt
@@ -1,0 +1,6 @@
+IMPORTANT: Starting with this version, CMDBSyncer enforces strict SSL certificate verification by default.
+
+Please check if your exports are still running without errors.
+If you encounter connection errors, configure the certificates in the respective accounts.
+
+More information: https://docs.cmdbsyncer.de/basics/accounts/#ssl-certificate-verification


### PR DESCRIPTION
Enable accounts to configure custom CA certificate chains and root CA certificates for SSL verification. Update the build trigger to specify branches, increment the version, and introduce a notice system for important messages.